### PR TITLE
adding function load

### DIFF
--- a/httpimport.py
+++ b/httpimport.py
@@ -285,3 +285,11 @@ __all__ = [
     'github_repo',
     'bitbucket_repo',
 ]
+
+
+
+def load(module,url):
+    import importlib
+    with remote_repo([module], url) :
+        module = importlib.import_module(module)
+    return module


### PR DESCRIPTION
This pull request actually creates the ability to hold this module as an object in the code
e.g  
module1 = httpimport.load(module,url) 
module2 = httpimport.load(module,url)

I dont know if i am the only one feeling that this module is supposed to be in vanilla python