### PR TITLE
Fixes nested relative package module imports/Fixes incorrect module __package__ attribute

### DIFF
--- a/httpimport.py
+++ b/httpimport.py
@@ -221,12 +221,16 @@ It is better to not use this class directly, but through its wrappers ('remote_r
         if module_type == 'package':
             mod.__package__ = name
         else:
+            #check if this could be a nested package
+            if len(name.split('.')[:-1]) > 1:
             #recursively find the package
-            pkg_name = '.'.join(name.split('.')[:-1])
-            while sys.modules[pkg_name].__package__ != pkg_name:
-                pkg_name = '.'.join(pkg_name.split('.')[:-1])
-            mod.__package__ = pkg_name
-
+                pkg_name = '.'.join(name.split('.')[:-1])
+                while sys.modules[pkg_name].__package__ != pkg_name:
+                    pkg_name = '.'.join(pkg_name.split('.')[:-1])
+                mod.__package__ = pkg_name
+            #if this could not be nested, we just use it's own name
+            else:
+                mod.__package__ = name.split('.')[0]
         try:
             mod.__path__ = ['/'.join(mod.__file__.split('/')[:-1]) + '/']
         except:

--- a/httpimport.py
+++ b/httpimport.py
@@ -221,7 +221,11 @@ It is better to not use this class directly, but through its wrappers ('remote_r
         if module_type == 'package':
             mod.__package__ = name
         else:
-            mod.__package__ = name.split('.')[0]
+            #recursively find the package
+            pkg_name = '.'.join(name.split('.')[:-1])
+            while sys.modules[pkg_name].__package__ != pkg_name:
+                pkg_name = '.'.join(pkg_name.split('.')[:-1])
+            mod.__package__ = pkg_name
 
         try:
             mod.__path__ = ['/'.join(mod.__file__.split('/')[:-1]) + '/']

--- a/httpimport.py
+++ b/httpimport.py
@@ -117,17 +117,19 @@ It is better to not use this class directly, but through its wrappers ('remote_r
 
     def _mod_to_filepaths(self, fullname, compiled=False):
         suffix = '.pyc' if compiled else '.py'
-        # get the python module name
-        py_filename = fullname.replace(".", os.sep) + suffix
-        # get the filename if it is a package/subpackage
-        py_package = fullname.replace(
-            ".", os.sep, fullname.count(".") - 1) + "/__init__" + suffix
-
         if self.is_archive:
+            # get the python module name
+            py_filename = fullname.replace(".", os.sep) + suffix
+            # get the filename if it is a package/subpackage
+            py_package = fullname.replace(
+                ".", os.sep, fullname.count(".") - 1) + "/__init__" + suffix
             return {'module': py_filename, 'package': py_package}
         else:
             # if self.in_progress:
-            # py_package = fullname.replace(".", '/') + "/__init__" + suffix
+            # get the python module name
+            py_filename = fullname.replace(".", '/') + suffix
+            # get the filename if it is a package/subpackage
+            py_package = fullname.replace(".", '/') + "/__init__" + suffix
             return {
                 'module': self.base_url + py_filename,
                 'package': self.base_url + py_package

--- a/test.py
+++ b/test.py
@@ -53,10 +53,6 @@ class Test(unittest.TestCase):
         with httpimport.remote_repo("test_package", base_url='http://localhost:%d/' % self.PORT):
             import test_package
         self.assertTrue(test_package)
-        #subpackage with local imports
-        with httpimport.remote_repo("test_package", base_url='http://localhost:%d/' % self.PORT):
-            import test_package.b
-        self.assertTrue(test_package.b.mod.module_name() == test_package.b.mod2.mod2val)
 
     def test_dependent_HTTP(self):
         httpimport.INSECURE = True

--- a/test.py
+++ b/test.py
@@ -38,15 +38,25 @@ class Test(unittest.TestCase):
 
     def test_simple_HTTP(self):
         httpimport.INSECURE = True
+        #base package import
         with httpimport.remote_repo(base_url='http://localhost:%d/' % self.PORT):
             import test_package
         self.assertTrue(test_package)
+        #subpackage with local imports
+        with httpimport.remote_repo(base_url='http://localhost:%d/' % self.PORT):
+            import test_package.b
+        self.assertTrue(test_package.b.mod.module_name() == test_package.b.mod2.mod2val)
 
     def test_simple_HTTP_pre_0_9_0(self):
         httpimport.INSECURE = True
+        #base package import
         with httpimport.remote_repo("test_package", base_url='http://localhost:%d/' % self.PORT):
             import test_package
         self.assertTrue(test_package)
+        #subpackage with local imports
+        with httpimport.remote_repo("test_package", base_url='http://localhost:%d/' % self.PORT):
+            import test_package.b
+        self.assertTrue(test_package.b.mod.module_name() == test_package.b.mod2.mod2val)
 
     def test_dependent_HTTP(self):
         httpimport.INSECURE = True

--- a/test_web_directory/test_package/__init__.py
+++ b/test_web_directory/test_package/__init__.py
@@ -1,2 +1,1 @@
-from . import a, b
 __all__ = ["module1", "module2"]

--- a/test_web_directory/test_package/__init__.py
+++ b/test_web_directory/test_package/__init__.py
@@ -1,1 +1,2 @@
+from . import a, b
 __all__ = ["module1", "module2"]

--- a/test_web_directory/test_package/a/__init__.py
+++ b/test_web_directory/test_package/a/__init__.py
@@ -1,0 +1,1 @@
+from . import mod

--- a/test_web_directory/test_package/b/__init__.py
+++ b/test_web_directory/test_package/b/__init__.py
@@ -1,0 +1,1 @@
+from . import mod

--- a/test_web_directory/test_package/b/mod.py
+++ b/test_web_directory/test_package/b/mod.py
@@ -1,2 +1,4 @@
+from .mod2 import mod2val
+
 def module_name():
-    return 'Module B'
+    return mod2val

--- a/test_web_directory/test_package/b/mod2.py
+++ b/test_web_directory/test_package/b/mod2.py
@@ -1,1 +1,1 @@
-mod2val = "Module b"
+mod2val = "Module B"

--- a/test_web_directory/test_package/b/mod2.py
+++ b/test_web_directory/test_package/b/mod2.py
@@ -1,0 +1,1 @@
+mod2val = "Module b"


### PR DESCRIPTION
This is a fix for #40, This fix essentially starts at the name of the module being imported and walks backwards looking in sys.modules where `sys.modules[path].__package__ == path`, and then uses that as the package since it would be the nearest level. This has an additional benefit of fixing nested relative package module imports as `__package__` is what python uses to determine where to import from when presented with a relative path.