### PR TITLE
adds proxy support

### DIFF
--- a/test.py
+++ b/test.py
@@ -36,6 +36,10 @@ class Test(unittest.TestCase):
             del sys.modules['test_package.a']
         if 'test_package.b' in sys.modules:
             del sys.modules['test_package.b']
+        if 'test_package.b.mod' in sys.modules:
+            del sys.modules['test_package.b.mod']
+        if 'test_package.b.mod2' in sys.modules:
+            del sys.modules['test_package.b.mod2']
         # print(sys.meta_path)
         # print (sys.modules.keys())
 

--- a/test.py
+++ b/test.py
@@ -264,6 +264,7 @@ def _run_webserver():
             try:
                 url_check = urlopen(url)
                 self.send_response(200)
+                self.send_header('Content-Type',url_check.headers['Content-Type'])
                 self.end_headers()
                 self.copyfile(urlopen(url), self.wfile)
             except:

--- a/test_web_directory/test_package/b/__init__.py
+++ b/test_web_directory/test_package/b/__init__.py
@@ -1,1 +1,1 @@
-from . import mod
+from . import mod, mod2


### PR DESCRIPTION
This PR would add support for proxied web requests, which should address #18 . This is done by initializing an OpenerDirector if PROXY is defined. 
The PROXY object must be a dictionary object with an `http` and/or `https` key with the value being the upstream proxy. Here is an example use of the PROXY attribute
```
import httpimport
httpimport.INSECURE=True
httpimport.PROXY={'http':'http://127.0.0.1:8080'}
with httpimport.remote_repo('http://192.168.3.72:8000/site-packages'):
  import foo.bar
```