### PR TITLE
simplifies urlopen header parsing logic

### DIFF
--- a/httpimport.py
+++ b/httpimport.py
@@ -120,13 +120,9 @@ def http(url, headers={}, method='GET', proxy=None):
     try:
         resp = _urlopen(req)
         try:  # Python2 Approach
-            headers = {  # Parse Header List to Dict
-                h.split(':', 1)[0].lower(): h.split(':', 1)[1].strip()
-                for h in resp.info().__dict__["headers"]
-            }
+            headers = { k.lower(): v for k, v in resp.headers.dict.items() }
         except KeyError:  # Python3 Approach
-            headers = {k.lower(): v for k, v in resp.info().__dict__[
-                "_headers"]}
+            headers = { k.lower(): v for k, v in resp.getheaders() }
 
         return {'code': resp.code, 'body': resp.read(), 'headers': headers}
     except HTTPError as he:

--- a/httpimport.py
+++ b/httpimport.py
@@ -121,7 +121,7 @@ def http(url, headers={}, method='GET', proxy=None):
         resp = _urlopen(req)
         try:  # Python2 Approach
             headers = { k.lower(): v for k, v in resp.headers.dict.items() }
-        except KeyError:  # Python3 Approach
+        except AttributeError:  # Python3 Approach
             headers = { k.lower(): v for k, v in resp.getheaders() }
 
         return {'code': resp.code, 'body': resp.read(), 'headers': headers}

--- a/test.py
+++ b/test.py
@@ -64,12 +64,12 @@ class Test(unittest.TestCase):
 
     def test_headers(self):
         #use the http method and parse the headers key
-        resp = httpimport.http(urls['web_dir'] % port)
+        resp = httpimport.http(URLS['web_dir'] % PORT)
         self.assertTrue('text' in resp['headers']['content-type'])
 
     def test_simple_HTTP(self):
         # base package import
-        with httpimport.remote_repo(urls['web_dir'] % port):
+        with httpimport.remote_repo(URLS['web_dir'] % PORT):
             import test_package
         self.assertTrue(test_package)
 

--- a/test.py
+++ b/test.py
@@ -62,9 +62,14 @@ class Test(unittest.TestCase):
         # Get back to defaults
         httpimport.set_profile(httpimport._DEFAULT_INI_CONFIG)
 
+    def test_headers(self):
+        #use the http method and parse the headers key
+        resp = httpimport.http(urls['web_dir'] % port)
+        self.assertTrue('text' in resp['headers']['content-type'])
+
     def test_simple_HTTP(self):
         # base package import
-        with httpimport.remote_repo(URLS['web_dir'] % PORT):
+        with httpimport.remote_repo(urls['web_dir'] % port):
             import test_package
         self.assertTrue(test_package)
 


### PR DESCRIPTION
Hey, digging the new codebase. wasn't sure if you'd be interested, but I had a slightly simpler way to parse the headers returned by urlopen. The python3 change is probably more opinionated, but in python2's urllib2.request the returned object from urlopen actually contains a headers.dict which is already in a dictionary format, so that makes it to where you can almost parse them with  similar programming patterns, and no string parsing is always a plus (python 2)