### PR TITLE
Raises error if error occurs while importing into sys.modules

### DIFF
--- a/httpimport.py
+++ b/httpimport.py
@@ -457,11 +457,13 @@ class HttpImporter(object):
         # Execute the module/package code into the Module object
         try:
             exec(self.modules[fullname]['content'], mod.__dict__)
-        except BaseException:
+        except BaseException as e:
             if not sys_modules:
                 logger.warning(
                     "[-] Module/Package '%s' cannot be imported without adding it to sys.modules. Might contain relative imports." %
                     fullname)
+            else:
+                raise e
         return mod
 
     def load_module(self, fullname):


### PR DESCRIPTION
Fixes issue mentioned in #54 
This aims to fix a longstanding issue which arises when an error occurs during an import. The current behavior allows httpimport to silently error and retain partial packages/modules in sys.modules. This gives the illusion of a successful import. What this commit does is has httpimport raise the encountered error so that python's native import protocol can clean up the remnants of the failed import.