### PR TITLE
Add explicit import importlib.machinery

### DIFF
--- a/httpimport.py
+++ b/httpimport.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import importlib
+import importlib.machinery
 import io
 import json
 import logging


### PR DESCRIPTION
My Python 3.12 code would not run unless importlib.machinery was explicitly imported.

The error was:
...\httpimport.py", line 343, in find_spec
    return importlib.machinery.ModuleSpec(
builtins.AttributeError: module 'importlib' has no attribute 'machinery'

After adding an explicit `import importlib.machinery` the code runs fine in Python 3.7 to 3.12